### PR TITLE
httplib changed to http.client for Python3 support

### DIFF
--- a/build/lib/drealtime/__init__.py
+++ b/build/lib/drealtime/__init__.py
@@ -1,6 +1,10 @@
-import httplib
 import socket
 from django.conf import settings
+
+try:
+    import httplib
+except:
+    import http.client as  httplib
 
 try:
     from django.utils import simplejson as json


### PR DESCRIPTION
httplib has been renamed to http.client in python3. https://docs.python.org/3/library/http.client.html 
