### PR TITLE
Update import httplib for Python 3 compatibility

### DIFF
--- a/drealtime/__init__.py
+++ b/drealtime/__init__.py
@@ -1,4 +1,9 @@
-import httplib
+try:
+    # Python 2
+    import httplib
+except ImportError:
+    # Python 3
+    import http.client as httplib
 import socket
 from django.conf import settings
 try:


### PR DESCRIPTION
When using this library with Python 3 django syncdb throws exception 'Import Error' no module named httplib so I updated imports for this case
